### PR TITLE
Fix bug where characters did not move on fast machines

### DIFF
--- a/src/TileEngine/Actor_MoveOrder.cpp
+++ b/src/TileEngine/Actor_MoveOrder.cpp
@@ -16,8 +16,8 @@ const int debugFlag = DEBUG_NPC;
 //#define DRAW_PATH
 
 Actor::MoveOrder::MoveOrder(Actor& actor, const shapes::Point2D& destination, EntityGrid& entityGrid)
-: Order(actor), pathInitialized(false), movementBegun(false), dst(destination), entityGrid(entityGrid)
-{
+: Order(actor), pathInitialized(false), movementBegun(false), dst(destination), entityGrid(entityGrid), cumulativeDistanceCovered(0)
+{	
 }
 
 Actor::MoveOrder::~MoveOrder()
@@ -71,8 +71,13 @@ bool Actor::MoveOrder::perform(long timePassed)
    shapes::Point2D location = actor.getLocation();
    MovementDirection newDirection = actor.getDirection();
    const float vel = actor.getMovementSpeed();
-   long distanceCovered = timePassed * vel;
-   
+   cumulativeDistanceCovered +=timePassed * vel;   
+   long distanceCovered = 0;
+   if(cumulativeDistanceCovered > 1.0)
+   {
+	   distanceCovered = floor(cumulativeDistanceCovered);
+	   cumulativeDistanceCovered -= distanceCovered;
+   }
    // If first run, get the best computed path (RFW), end frame
    // loop infinitely
    //      if there is no next vertex

--- a/src/TileEngine/Actor_Orders.h
+++ b/src/TileEngine/Actor_Orders.h
@@ -40,6 +40,9 @@ class Actor::MoveOrder : public Actor::Order
    EntityGrid& entityGrid;
    EntityGrid::Path path;
 
+   /** Total distance for the character to move. */
+   float cumulativeDistanceCovered;
+
    void updateDirection(MovementDirection newDirection, bool moving);
    void updateNextWaypoint(shapes::Point2D location, MovementDirection& direction);
 

--- a/src/TileEngine/PlayerCharacter.cpp
+++ b/src/TileEngine/PlayerCharacter.cpp
@@ -19,7 +19,7 @@ const std::string PlayerCharacter::WALKING_PREFIX = "walk";
 const std::string PlayerCharacter::STANDING_PREFIX = "stand";
 
 PlayerCharacter::PlayerCharacter(EntityGrid& map, const std::string& sheetName)
-                                              : Actor("player", sheetName, map, 0, 0, 1.0f, DOWN), active(false)
+                                              : Actor("player", sheetName, map, 0, 0, 1.0f, DOWN), active(false), cumulativeDistanceCovered(0)
 {
 }
 
@@ -81,7 +81,14 @@ void PlayerCharacter::step(long timePassed)
    if(moving)
    {
       flushOrders();
-      int distanceTraversed = getMovementSpeed() * (timePassed / 5);
+	  /** \todo This algorithm is different from Actor_MoveOrder.cpp, synchronize. */
+	  cumulativeDistanceCovered += getMovementSpeed() * (timePassed / 5.0);
+      int distanceTraversed = 0;
+	  if(cumulativeDistanceCovered > 1.0)
+	  {
+		  distanceTraversed = floor(cumulativeDistanceCovered);
+		  cumulativeDistanceCovered -= distanceTraversed;
+	  }
       sprite->setAnimation(WALKING_PREFIX, direction);
       setDirection(direction);
       entityGrid.moveToClosestPoint(this, xDirection, yDirection, distanceTraversed);

--- a/src/TileEngine/PlayerCharacter.h
+++ b/src/TileEngine/PlayerCharacter.h
@@ -27,7 +27,10 @@ class PlayerCharacter : public Actor
    
    /** True iff the player entity is active on the map. */
    bool active;
-   
+  
+   /** Total distance for the character to move. */
+   float cumulativeDistanceCovered;
+
    public:   
       /**
        * Constructor.


### PR DESCRIPTION
Characters did not move on fast machines because if timePassed is less
than 5 milliseconds, character's distance to move will be 0.xxx, and since
a character can only move whole number distances and the variable tracking
the distance (distanceTraversed) is of type int, the distance is always 0. The
fix is to add a member variable (cumulativeDistanceCovered) to collect
these small distances, and move the character forward by the floor of
cumulativeDistanceCovered when it is greater than 1.0. The distance that
the character moved will then be subtracted from cumulativeDistanceCovered.
